### PR TITLE
Update check_graylog_node for graylog 2.3.1

### DIFF
--- a/externalscript/check_graylog_node
+++ b/externalscript/check_graylog_node
@@ -108,7 +108,9 @@ unlock()            { _lock u; }   # drop a lock
 ##### END FLOCK CONVENIENCE FUNCTION DEFINITIONS ##### 
 
 #CURL_BASE_CMD="curl -u ${USERNAME}:${PASSWORD}  -D /dev/fd/4 -sS http://${HOSTNAME}:${APIPORT}"
-CURL_BASE_CMD="curl -u ${USERNAME}:${PASSWORD} -sS http://${HOSTNAME}:${APIPORT}/api"
+#CURL_BASE_CMD="curl -u ${USERNAME}:${PASSWORD} -sS http://${HOSTNAME}:${APIPORT}/api"
+## For Graylog 2.3.1
+CURL_BASE_CMD="curl -u ${USERNAME}:${PASSWORD} -sS http://${HOSTNAME}:${APIPORT}"
 
 get_json_info() {
     # $1 = URI -- $2 filename


### PR DESCRIPTION
On graylog 2.3.1 version cannot parse json file from graylog server address with api at the end of URL.
If we remove api sub address, script can get json info.